### PR TITLE
refactor: add option to configure error propagation

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const SwaggerValidatorError = errorFactory('swagger_validator');
  * @param {Object} [options.jsdoc={}] - Extra configuration when format = 'jsdoc'.
  * @param {string} [options.validationEndpoint=null] - endpoint to do schemas validation agains the OpenAPI schema.
  * @param {string} [options.apiDocEndpoint=null] - endpoint to show UI based API documentation.
+ * @param {boolean} [options.propagateError=false] - Determines whether the internal Express error handler responds immediately or passes the validation error to the next error handler
  * @param {*} [options.validateRequests=true] - Determines whether the validator should validate requests.
  * @param {*} [options.validateResponses=true] - Determines whether the validator should validate responses. Also accepts response validation options.
  * @param {*} [options.validateSecurity=true] -Determines whether the validator should validate securities e.g. apikey, basic, oauth2, openid, etc
@@ -51,7 +52,7 @@ const init = async (app, options) => {
 	validationEndpoint.add(app, normalizedOptions);
 
 	await validator.init(app, normalizedOptions, spec);
-	customErrorHandler.add(app);
+	customErrorHandler.add(app, normalizedOptions);
 
 	debug('Middleware initialized!');
 };

--- a/lib/customErrorHandler.js
+++ b/lib/customErrorHandler.js
@@ -3,14 +3,19 @@ const debug = require('debug')('swagger-endpoint-validator:custom-error-handler'
 /**
  * Adds a custom error handler for the errors thrown by the validator.
  * @param {Object} app - Express application object.
+ * @param {Object} options - Configuration options.
  * @see https://github.com/cdimascio/express-openapi-validator#asyncawait
  */
-const add = app => {
+const add = (app, options) => {
 	debug('Adding custom error handler...');
 
-	app.use((error, _req, res, _next) => { // eslint-disable-line no-unused-vars
+	app.use((error, _req, res, next) => { // eslint-disable-line no-unused-vars
 		debug(JSON.stringify(error));
-		res.status(error.status || 500).send(error);
+		if (options.propagateError) {
+			next(error);
+		} else {
+			res.status(error.status || 500).send(error);
+		}
 	});
 
 	debug('Custom error handler added!');

--- a/test/error-options/e2e.test.js
+++ b/test/error-options/e2e.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const runServer = require('./fake-server');
+
+describe('error propagation', () => {
+	it('should propagate the error to the next error handler if propagateError is true', async () => {
+		const app = await runServer({ propagateError: true });
+		const myErrorHandler = jest.fn((error, _req, _res, next) => {
+			next(error);
+		});
+		app.use(myErrorHandler);
+		await request(app)
+			.get('/pets?limit=0');
+		expect(myErrorHandler).toHaveBeenCalled();
+	});
+
+	it('should not propagate the error to the next handler if propagateError is false', async () => {
+		const app = await runServer({ propagateError: false });
+		const myErrorHandler = jest.fn((error, _req, _res, next) => {
+			next(error);
+		});
+		app.use(myErrorHandler);
+		await request(app)
+			.get('/pets?limit=0');
+		expect(myErrorHandler).not.toHaveBeenCalled();
+	});
+
+	it('should not propagate the error to the next handler if propagateError is not defined', async () => {
+		const app = await runServer();
+		const myErrorHandler = jest.fn((error, _req, _res, next) => {
+			next(error);
+		});
+		app.use(myErrorHandler);
+		await request(app)
+			.get('/pets?limit=0');
+		expect(myErrorHandler).not.toHaveBeenCalled();
+	});
+});

--- a/test/error-options/fake-server.js
+++ b/test/error-options/fake-server.js
@@ -1,0 +1,171 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const validator = require('../..');
+
+const pets = [
+	{ id: 1, name: 'pet 1', tag: 'dog' },
+	{ id: 2, name: 'pet 2', tag: 'cat' },
+	{ id: 3, name: 'pet 3', tag: 'bird' },
+	{ id: 4, name: 'pet 4', tag: 'dog' },
+	{ id: 5, name: 'pet 5', tag: 'cat' },
+	{ id: 6, name: 'pet 6', tag: 'bird' },
+];
+
+const wrongPets = [
+	{ id: 1, tag: 'dog' },
+	{ id: 2, tag: 'cat' },
+	{ id: 3, tag: 'bird' },
+	{ id: 4, tag: 'dog' },
+	{ id: 5, tag: 'cat' },
+	{ id: 6, tag: 'bird' },
+];
+
+const runServer = async (options = {}) => {
+	const app = express();
+	app.use(bodyParser.urlencoded({ extended: true }));
+	app.use(bodyParser.json());
+
+	await validator.init(app, {
+		validationEndpoint: '/test',
+		apiDocEndpoint: '/docs',
+		format: 'yaml_jsdoc',
+		yaml_jsdoc: {
+			swaggerDefinition: {
+				openapi: '3.0.0',
+				info: {
+					version: '1.0.0',
+					title: 'Swagger Petstore',
+					description: 'A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification',
+					termsOfService: 'http://swagger.io/terms/',
+					contact: {
+						name: 'Swagger API Team',
+						email: 'apiteam@swagger.io',
+						url: 'http://swagger.io',
+					},
+					license: {
+						name: 'Apache 2.0',
+						url: 'https://www.apache.org/licenses/LICENSE-2.0.html',
+					},
+				},
+			},
+			apis: [
+				'./test/yaml_jsdoc/fake-server.js',
+				'./test/yaml_jsdoc/components.js',
+			],
+		},
+		...options,
+	});
+
+	/**
+	 * @swagger
+	 *
+	 * /pets:
+	 *   get:
+	 *     description: |
+	 *       Returns all pets from the system that the user has access to
+	 *     operationId: findPets
+	 *     parameters:
+	 *       - name: tags
+	 *         in: query
+	 *         description: tags to filter by
+	 *         required: false
+	 *         style: form
+	 *         schema:
+	 *           type: array
+	 *           items:
+	 *             type: string
+	 *       - name: limit
+	 *         in: query
+	 *         description: maximum number of results to return
+	 *         required: false
+	 *         schema:
+	 *           type: integer
+	 *           format: int32
+	 *           minimum: 1
+	 *           maximum: 50
+	 *       - name: wrong
+	 *         in: query
+	 *         description: flag to force the server to return invalid response
+	 *         required: false
+	 *         schema:
+	 *           type: boolean
+	 *     responses:
+	 *       '200':
+	 *         description: pet response
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               type: array
+	 *               items:
+	 *                 $ref: '#/components/schemas/Pet'
+	 *       default:
+	 *         description: unexpected error
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               $ref: '#/components/schemas/Error'
+	 */
+	app.get(
+		'/pets',
+		(req, res) => {
+			const { wrong } = req.query;
+			if (wrong) {
+				res.status(200).json(wrongPets);
+			} else {
+				res.status(200).json(pets);
+			}
+		},
+	);
+
+	/**
+	 * @swagger
+	 *
+	 * /pets:
+	 *   post:
+	 *     description: Creates a new pet in the store. Duplicates are allowed
+	 *     operationId: addPet
+	 *     requestBody:
+	 *       description: Pet to add to the store
+	 *       required: true
+	 *       content:
+	 *         application/json:
+	 *           schema:
+	 *             $ref: '#/components/schemas/NewPet'
+	 *     parameters:
+	 *       - name: wrong
+	 *         in: query
+	 *         description: flag to force the server to return invalid response
+	 *         required: false
+	 *         schema:
+	 *           type: boolean
+	 *     responses:
+	 *       '200':
+	 *         description: pet response
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               $ref: '#/components/schemas/Pet'
+	 *       default:
+	 *         description: unexpected error
+	 *         content:
+	 *           application/json:
+	 *             schema:
+	 *               $ref: '#/components/schemas/Error'
+	 */
+	app.post(
+		'/pets',
+		(req, res) => {
+			const { wrong } = req.query;
+			if (wrong) {
+				res.status(200).json({ ...req.body });
+			} else {
+				res.status(200).json({ id: 7, ...req.body });
+			}
+		},
+	);
+
+	return app;
+};
+
+module.exports = runServer;


### PR DESCRIPTION
## Description
Provide an additional option to control whether the library should send the response with the validation error or let it get passed to the next error handler.

## Related Issue
No issue related so far. I will add the link when created.

## Motivation and Context
I'm working on a project in which it is necessary to register errors to a vendor analytic server. One of the approaches using the SDK of that tool is by setting an Express error handler and explicitly executing one of the functions available on their API. In our project, we are using `swagger-endpoint-validation`. The problem is that in the current implementation, validation errors are always captured, and therefore they never reach our error handler. We've tried initializing `swagger-endpoint-validation` after our own error handlers have been registered in the Express stack, but then the payload and params validation is not performed, so faulty data reaches our business logic making it crash.

After checking with the team, we agreed that adding an additional option that controls whether the error handle that this library uses propagates the error, or sends the response with the validation error.

To ensure backward compatibility, the error propagation is off by default. So current users of this library are not forced to set their own error middleware necessarily.

## How Has This Been Tested?
I've used Node 16, as specified in the `.nvmrc`. Tests consist of 3 test cases:

- If `propagateError` is `true`, the validation error should reach the next error handler
- If `propagateError` is `false` or not defined, the validation error should not reach the next error handler

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
